### PR TITLE
fix usage for windows os

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ mosdns-cn -s :53 --upstream https://8.8.8.8/dns-query
 资源分流本地/远程域名并且屏蔽广告域名:
 
 ```shell
-mosdns-cn -s :53 --blacklist-domain 'geosite.dat:category-ads-all' --local-upstream https://223.5.5.5/dns-query --local-domain 'geosite.dat:cn' --local-ip 'geoip.dat:cn' --remote-upstream https://8.8.8.8/dns-query --remote-domain 'geosite.dat:geolocation-!cn'
+mosdns-cn -s :53 --blacklist-domain "geosite.dat:category-ads-all" --local-upstream https://223.5.5.5/dns-query --local-domain "geosite.dat:cn" --local-ip "geoip.dat:cn" --remote-upstream https://8.8.8.8/dns-query --remote-domain "geosite.dat:geolocation-!cn"
 ```
 
 ### 使用 `--service` 一键将 mosdns-cn 安装到系统服务实现自启


### PR DESCRIPTION
示例的命令在 Windows 系统 cmd 中执行会报错：

```
mosdns-cn -s :53 --blacklist-domain 'geosite.dat:category-ads-all' --local-upstream https://223.6.6.6/dns-query --local-domain 'geosite.dat:cn' --local-ip 'geoip.dat:cn' --remote-upstream https://1.1.1.1/dns-query --remote-domain 'geosite.dat:geolocation-!cn'
2021-12-07T11:28:31.050+0800    info    mosdns-cn/main.go:190   mosdns-cn ver: 1.1.3
2021-12-07T11:28:31.062+0800    info    mosdns-cn/main.go:191   arch: amd64, os: windows, go: go1.16.10
2021-12-07T11:28:31.063+0800    fatal   mosdns-cn/main.go:195   failed to init entry, failed to init blacklist, failed to load file 'geosite.dat:category-ads-all': open 'geosite.dat: The system cannot find the file specified.
```

原因是单引号被当成了路径的一部分。

改成双引号后可以解决问题。

```
mosdns-cn -s :53 --blacklist-domain "geosite.dat:category-ads-all" --local-upstream https://223.6.6.6/dns-query --local-domain "geosite.dat:cn" --local-ip "geoip.dat:cn" --remote-upstream https://1.1.1.1/dns-query --remote-domain "geosite.dat:geolocation-!cn"
2021-12-07T11:39:58.105+0800    info    mosdns-cn/main.go:190   mosdns-cn ver: 1.1.3
2021-12-07T11:39:58.118+0800    info    mosdns-cn/main.go:191   arch: amd64, os: windows, go: go1.16.10
2021-12-07T11:39:58.388+0800    info    mosdns-cn/main.go:218   server started
```

此修改应该不会影响其他系统，但限于我没有环境，所以 **没有测试**。